### PR TITLE
Update rosenheim scraper and geojson

### DIFF
--- a/original/rosenheim.geojson
+++ b/original/rosenheim.geojson
@@ -390,7 +390,7 @@
         "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p8-beilhack-kinopolis",
         "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
         "address": "Kufsteiner Str.",
-        "capacity": 160,
+        "capacity": 180,
         "has_live_capacity": true
       },
       "geometry": {

--- a/original/rosenheim.geojson
+++ b/original/rosenheim.geojson
@@ -1,0 +1,445 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp10stadtcenter",
+        "name": "P10 Stadtcenter",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p10-stadtcenter",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Brixstraße 1",
+        "capacity": 55,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.127699,
+          47.853346
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp11beilhackgiessereistrasse",
+        "name": "P11 Beilhack-Gießereistraße",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p11-beilhack-giessereistrasse",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Gießereistraße 6",
+        "capacity": 170,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.126676,
+          47.849744
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp12bahnhofnord",
+        "name": "P12 Bahnhof Nord",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p12-bahnhof-nord",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Eduard-Rüber-Straße 5",
+        "capacity": 241,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.114008,
+          47.852342
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp13papinstrasse",
+        "name": "P13 Papinstraße",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p13-papinstrasse",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Papinstraße",
+        "capacity": 50,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.120291,
+          47.852556
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp14posthoefe",
+        "name": "P14 Posthöfe",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p14-posthoefe",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Anton-Kathrein-Straße 4",
+        "capacity": 40,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.121413,
+          47.850933
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp15luitpoldhaus",
+        "name": "P15 Luitpoldhaus",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p15-luitpoldhaus",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Luitpoldstraße 5",
+        "capacity": 35,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.119647,
+          47.851211
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp16ruedorfferpassage",
+        "name": "P16 Ruedorffer Passage",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p16-ruedorffer-passage",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Ruedorfferstraße",
+        "capacity": 40,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.127767,
+          47.857127
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp18eisstadion",
+        "name": "P18 Eisstadion",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p18-eisstadion",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Brianconstraße 12A",
+        "capacity": 17,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.13138,
+          47.850842
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp19klinikum",
+        "name": "P19 Klinikum",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p19-klinikum-kaiserbad",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Rechenauerstraße 2",
+        "capacity": 65,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.127549,
+          47.861526
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp1zentrum",
+        "name": "P1 Zentrum",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p1-zentrum",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Hammerweg 1",
+        "capacity": 264,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.127195,
+          47.852389
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp20inderschmucken",
+        "name": "P20 In der Schmucken",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p20-in-der-schmucken",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "In d. Schmucken 12",
+        "capacity": 57,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.131835,
+          47.858744
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp21luitpoldhalle",
+        "name": "P21 Luitpoldhalle",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p21-luitpoldhalle",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Unnamed Road",
+        "capacity": 60,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.119421,
+          47.857758
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp22prinzregentenstrasse",
+        "name": "P22 Prinzregentenstraße",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p22-prinzregentenstrasse",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Prinzregentenstraße 14",
+        "capacity": 30,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.124614,
+          47.856073
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp2kuko",
+        "name": "P2 KU'KO",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p2-kuko",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Kufsteiner Str. 4",
+        "capacity": 138,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.125822,
+          47.853065
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp3rathaus",
+        "name": "P3 Rathaus",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p3-rathaus",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Königstraße 24",
+        "capacity": 30,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.129304,
+          47.853206
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp4mitte",
+        "name": "P4 Mitte",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p4-mitte",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Frühlingstraße",
+        "capacity": 245,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.124722,
+          47.856453
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp5loretowiese",
+        "name": "P5 Loretowiese",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p5-loretowiese",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Kapuzinerweg 1",
+        "capacity": 700,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.125289,
+          47.859583
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp6salinplatz",
+        "name": "P6 Salinplatz",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p6-salinplatz",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Salinstraße",
+        "capacity": 222,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.12278,
+          47.852644
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp7altstadtost",
+        "name": "P7 Altstadt-Ost",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p7-altstadt-ost",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "In d. Schmucken",
+        "capacity": 82,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.131288,
+          47.857475
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp8beilhackkinopolis",
+        "name": "P8 Beilhack-Kinopolis",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p8-beilhack-kinopolis",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Kufsteiner Str.",
+        "capacity": 160,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.12616,
+          47.850594
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimp9amklinikum",
+        "name": "P9 Am Klinikum",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p9-am-klinikum",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "In d. Schmucken",
+        "capacity": 396,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.13279,
+          47.858313
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "rosenheimprklepperstrasse",
+        "name": "P+R Klepperstraße",
+        "type": "garage",
+        "public_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken/p-r-klepperstrasse",
+        "source_url": "https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        "address": "Klepperstraße 17",
+        "capacity": 395,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.119682,
+          47.84782
+        ]
+      }
+    }
+  ]
+}

--- a/original/rosenheim.py
+++ b/original/rosenheim.py
@@ -42,13 +42,13 @@ class Rosenheim(ScraperBase):
         for lot in lot_infos :
             internal_lot_id = lot["external_id"]
             realtime_info = dataJSON.get(str(internal_lot_id))
-            
+            num_free = int_or_none(realtime_info['currentParkingSpacesCount'])
             lots.append(
                 LotData(
                     timestamp=timestamp,
                     id=lot["id"],
-                    status=LotData.Status.open,
-                    num_free=int_or_none(realtime_info['currentParkingSpacesCount']),
+                    status=LotData.Status.open if num_free else LotData.Status.nodata,
+                    num_free=num_free,
                     capacity=int_or_none(lot["capacity"]),
                 )
             )

--- a/original/rosenheim.py
+++ b/original/rosenheim.py
@@ -40,7 +40,7 @@ class Rosenheim(ScraperBase):
 
         lots = []
         for lot in lot_infos :
-            internal_lot_id = lot["internal_id"]
+            internal_lot_id = lot["external_id"]
             realtime_info = dataJSON.get(str(internal_lot_id))
             
             lots.append(
@@ -59,8 +59,8 @@ class Rosenheim(ScraperBase):
         lot_dicts = self._get_lot_infos_as_dicts()
         lots = []
         for lot in lot_dicts:
-            # For now, remove internal_id, which is not supported by LotInfo yet
-            lot.pop("internal_id")
+            # For now, remove external_id, which is not supported by LotInfo yet
+            lot.pop("external_id")
             lots.append(LotInfo(**lot))
   
         return lots
@@ -82,7 +82,7 @@ class Rosenheim(ScraperBase):
 
             lots.append({
                 "id": lot_id,
-                "internal_id": marker["id"],
+                "external_id": marker["id"],
                 "name": lot_name,
                 "type": "garage",
                 "latitude": lat or None,

--- a/original/rosenheim.py
+++ b/original/rosenheim.py
@@ -11,51 +11,87 @@ class Rosenheim(ScraperBase):
     POOL = PoolInfo(
         id="rosenheim",
         name="Rosenheim",
-        public_url="https://www.rosenheim.de/stadt-buerger/verkehr/parken.html",
-        source_url="https://www.rosenheim.de/index.php?eID=jwParkingGetParkings",
+        public_url="https://www.rosenheim.de/buergerservice/mobilitaet/parken",
+        source_url="https://www.rosenheim.de/?id=1&type=1452982642&L=0&tx_in2rocitymap_in2rocitymap%5Btype%5D=parking_space&tx_in2rocitymap_in2rocitymap%5Blang%5D=de-DE&tx_in2rocitymap_in2rocitymap%5BdirectoryFilter%5D=544&tx_in2rocitymap_in2rocitymap%5BapiAction%5D=getAvailableParking&tx_in2rocitymap_in2rocitymap%5BCategory%5D=21",
         timezone="Europe/Berlin",
         attribution_contributor="Stadt Rosenheim",
         attribution_license=None,
         attribution_url=None,
     )
 
+    LOT_URL = "https://www.rosenheim.de/?id=1&type=1452982642&L=0&tx_in2rocitymap_in2rocitymap%5Btype%5D=parking_space&tx_in2rocitymap_in2rocitymap%5Blang%5D=de-DE&tx_in2rocitymap_in2rocitymap%5BdirectoryFilter%5D=544&tx_in2rocitymap_in2rocitymap%5BapiAction%5D=categorizedMap&tx_in2rocitymap_in2rocitymap%5BCategory%5D=21"
+    
     def get_lot_data(self) -> List[LotData]:
+        """
+        Rosenheim's source_url refers to a json on following structure:
+         {
+            "<parkingid>":{"id":"<parkingid>","currentParkingSpacesCount":"<num_free>"},
+            ...
+         }"
+
+         The parkingid is an internal numeric id, which currently is not available via LotInfo.
+         For this reason, we request the parkings as well dynamically and use their IDs.
+        """
         timestamp = self.now()
         dataJSON = self.request_json(self.POOL.source_url)
 
+        # Retrieve static parking information to access internal id
+        lot_infos = self._get_lot_infos_as_dicts()
+
         lots = []
-
-        # over all parking-lots
-        for parking_lot in dataJSON :
-            parking_name = parking_lot['title']
-            if parking_name != 'Reserve':
-                parking_status = (
-                    LotData.Status.open if parking_lot['isOpened']
-                    else LotData.Status.closed
+        for lot in lot_infos :
+            internal_lot_id = lot["internal_id"]
+            realtime_info = dataJSON.get(str(internal_lot_id))
+            
+            lots.append(
+                LotData(
+                    timestamp=timestamp,
+                    id=lot["id"],
+                    status=LotData.Status.open,
+                    num_free=int_or_none(realtime_info['currentParkingSpacesCount']),
+                    capacity=int_or_none(lot["capacity"]),
                 )
-
-                lots.append(
-                    LotData(
-                        timestamp=timestamp,
-                        id=name_to_legacy_id("rosenheim", parking_name),
-                        status=parking_status,
-                        num_free=int_or_none(parking_lot['free']),
-                        capacity=int_or_none(parking_lot["parkings"]),
-                    )
-                )
+            )
 
         return lots
 
     def get_lot_infos(self) -> List[LotInfo]:
-        LEGACY_TO_NEW_NAME = {
-            "P8 Beilhack-Citydome": "P8 Beilhack-Kinopolis",
-            "P11 Beilhack-Gießereistr.": "P11 Beilhack-Gießereistraße",
-        }
-        lots = self.get_v1_lot_infos_from_geojson("Rosenheim")
-        for lot in lots:
-            lot.has_live_capacity = True
-            if lot.name in LEGACY_TO_NEW_NAME:
-                lot.name = LEGACY_TO_NEW_NAME[lot.name]
-                lot.id = name_to_legacy_id("rosenheim", lot.name)
+        lot_dicts = self._get_lot_infos_as_dicts()
+        lots = []
+        for lot in lot_dicts:
+            # For now, remove internal_id, which is not supported by LotInfo yet
+            lot.pop("internal_id")
+            lots.append(LotInfo(**lot))
+  
+        return lots
 
+    def name_to_legacy_id(self, lot_name) -> str:
+        legacy_name = lot_name.replace('-', '').replace(' ', '').replace('+', '')
+        return name_to_legacy_id(self.POOL.id, legacy_name)
+
+    def _get_lot_infos_as_dicts(self) -> dict:
+        geojson_response = self.request_json(self.LOT_URL)
+
+        lots = []
+        for marker in geojson_response['markers']:
+            lot_name = marker["name"]
+            lot_id = self.name_to_legacy_id(lot_name)
+            lat = marker["position"]["lat"]
+            lng = marker["position"]["lng"]
+            lot_url = "https://www.rosenheim.de"+marker["externalDetailPage"]
+
+            lots.append({
+                "id": lot_id,
+                "internal_id": marker["id"],
+                "name": lot_name,
+                "type": "garage",
+                "latitude": lat or None,
+                "longitude": lng or None,
+                "public_url": lot_url,
+                "source_url": self.POOL.public_url,
+                "address": marker["address"].split("<")[0],
+                "capacity": marker["parkingSpaces"],
+                "has_live_capacity": marker["fetchDynamicParkingSpacesCount"],
+            })
+            
         return lots


### PR DESCRIPTION
This PR updates Rosenheim scraper and geojson.

However, two questions came up:

* I'm not aware of the conventions regarding backward compatibility. In `rosenheim.get_lot_infos()` I currently still request v1 lot_info information but don't use it. Only currently via source_url retrievable lot information is returned. How should these be merged? Should old parking lots still be returned and with which ID? the new one converted to the legacy ID?
* rosenheim publishes two publications, one providing static lot information, one dynamic occupancy data. Both are linked via an external, numeric id, which currently can't be persisted via `LotInfo`. This is a scenario, which I expect to become a lot more usual, especially for cities publishing DATEXII publications. IMHO, LotInfo should be extended and receive a new optional external_id, wdyt?