### PR TITLE
Update wiesbaden scraper and geojson

### DIFF
--- a/original/wiesbaden.geojson
+++ b/original/wiesbaden.geojson
@@ -8,7 +8,7 @@
         "name": "PH City 2",
         "type": "garage",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=233&Y=484",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Schwalbacher Str. 38-42",
         "capacity": 240,
         "has_live_capacity": true
@@ -28,7 +28,7 @@
         "name": "PH Coulinstrasse",
         "type": "garage",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915658.2710851978%2C6458475.045241954%2C918830.4077590327%2C6461580.299516035&query_layers=parkhaeuser&X=296&Y=176",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Coulinstraße 5",
         "capacity": 343,
         "has_live_capacity": true
@@ -44,11 +44,31 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "wiesbadenphgaleriakaufhof",
+        "name": "PH Galeria Kaufhof",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
+        "address": "Luisenstraße 47",
+        "capacity": 168,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.23752,
+          50.07899
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "wiesbadenphkarstadt",
         "name": "PH Karstadt",
         "type": "garage",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=324&Y=505",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Neugasse 5",
         "capacity": 355,
         "has_live_capacity": true
@@ -64,20 +84,20 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "wiesbadenphluisenforum",
-        "name": "PH Luisenforum",
+        "id": "wiesbadenphlili",
+        "name": "PH Lili",
         "type": "garage",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=243&Y=606",
-        "address": "Karlstraße",
-        "capacity": 800,
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
+        "address": "Klingholzstraße",
+        "capacity": 370,
         "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.23508,
-          50.07839
+          8.24156,
+          50.07005
         ]
       }
     },
@@ -88,7 +108,7 @@
         "name": "PH Mauritius Galerie",
         "type": "garage",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=253&Y=461",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Schwalbacher Str. 53",
         "capacity": 563,
         "has_live_capacity": true
@@ -108,7 +128,7 @@
         "name": "PH Theater",
         "type": "garage",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915658.2710851978%2C6459688.48306598%2C918830.4077590327%2C6462793.737340063&query_layers=parkhaeuser&X=520&Y=430",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Thelemannstraße",
         "capacity": 320,
         "has_live_capacity": true
@@ -124,11 +144,51 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "wiesbadentgkurhauscasino",
+        "name": "TG Kurhaus/Casino",
+        "type": "underground",
+        "public_url": null,
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
+        "address": "Wilhelmstraße 49",
+        "capacity": 386,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.24443,
+          50.08537
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "wiesbadentglili",
+        "name": "TG Lili",
+        "type": "underground",
+        "public_url": null,
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
+        "address": "Bahnhofsplatz 3",
+        "capacity": 150,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.24177,
+          50.07134
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "wiesbadentgluisenplatz",
         "name": "TG Luisenplatz",
         "type": "underground",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=331&Y=613",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Rheinstrasse/Luisenplatz",
         "capacity": 292,
         "has_live_capacity": true
@@ -148,7 +208,7 @@
         "name": "TG Markt",
         "type": "underground",
         "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=401&Y=520",
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         "address": "Schillerplatz 2",
         "capacity": 540,
         "has_live_capacity": true
@@ -158,6 +218,26 @@
         "coordinates": [
           8.24214,
           50.08006
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "wiesbadentgrmcc",
+        "name": "TG RMCC",
+        "type": "underground",
+        "public_url": null,
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
+        "address": "Friedrich-Ebert-Allee 1",
+        "capacity": 700,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.24516,
+          50.07635
         ]
       }
     }

--- a/original/wiesbaden.geojson
+++ b/original/wiesbaden.geojson
@@ -44,26 +44,6 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "wiesbadenphgaleriakaufhof",
-        "name": "PH Galeria Kaufhof",
-        "type": "garage",
-        "public_url": null,
-        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
-        "address": "Luisenstraße 47",
-        "capacity": 168,
-        "has_live_capacity": true
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.23752,
-          50.07899
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
         "id": "wiesbadenphkarstadt",
         "name": "PH Karstadt",
         "type": "garage",
@@ -98,6 +78,26 @@
         "coordinates": [
           8.24156,
           50.07005
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "wiesbadenphluisenforum",
+        "name": "PH Luisenforum",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
+        "address": "Karlstraße",
+        "capacity": 800,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.23508,
+          50.07839
         ]
       }
     },

--- a/original/wiesbaden.py
+++ b/original/wiesbaden.py
@@ -12,94 +12,94 @@ class Wiesbaden(ScraperBase):
     POOL = PoolInfo(
         id="wiesbaden",
         name="Wiesbaden",
-        public_url="https://www.wiesbaden.de/leben-in-wiesbaden/verkehr/auto/parkhaeuser.php",
-        # that's only part of it
-        source_url="https://geoportal.wiesbaden.de/cgi-bin/mapserv.fcgi?map=d:/openwimap/umn/map/parkleitsystem/parkhaeuser.map&VERSION=1.3.0&service=WMS&request=GetFeatureInfo&version=1.1.1&layers=parkhaeuser&styles=&format=image%2Fpng&transparent=true&continuousWorld=true&tiled=true&info_format=text%2Fhtml&width=664&height=650&srs=EPSG%3A3857",
+        public_url="https://www.wiesbaden.de/leben-in-wiesbaden/verkehr/auto/parken/parkhaeuser.php",
+        source_url="https://geoportal.wiesbaden.de/parkleitsystem/parkhaeuser.php",
         timezone="Europe/Berlin",
         attribution_contributor="Stadt Wiesbaden",
         attribution_license=None,
         attribution_url=None,
     )
 
-    # These url parameters are copied from the browser
-    #   when clicking a lot on the map
-    # This is a bit crude and only works as long as a lot
-    #   does not change position (hehe)
-    # And new lots will not be detected. They could be
-    #   at least detected by the public_url's inline
-    #   javascript objects. Have a look and then decide
-    #   if this quick hack is too crude ;)
-    LOT_URL_PARAMS = [
-        "&bbox=915658.2710851978%2C6458475.045241954%2C918830.4077590327%2C6461580.299516035&query_layers=parkhaeuser&X=493&Y=116",
-        "&bbox=915658.2710851978%2C6458475.045241954%2C918830.4077590327%2C6461580.299516035&query_layers=parkhaeuser&X=296&Y=176",
-        "&bbox=915658.2710851978%2C6459688.48306598%2C918830.4077590327%2C6462793.737340063&query_layers=parkhaeuser&X=520&Y=430",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=253&Y=461",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=233&Y=484",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=324&Y=505",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=401&Y=520",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=277&Y=580",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=243&Y=606",
-        "&bbox=915667.8257137334%2C6459688.48306598%2C918839.9623875683%2C6462793.737340063&query_layers=parkhaeuser&X=331&Y=613",
-    ]
-
     STATUS_MAPPING = {
         "OK": LotData.Status.open,
         # TODO: After opening times lots show all numbers but this status
         #   so i guess it means "closed"
         "Nicht OK": LotData.Status.closed,
+        "Übertragungsstörung": LotData.Status.error,
     }
 
     def get_lot_data(self) -> List[LotData]:
+        timestamp = self.now()
+            
         lots = []
-        for timestamp, source_url, attributes in self.iter_lot_attributes():
+        for source_url, attributes in self.iter_lot_attributes():
+            if not "name" in attributes: 
+                log("Error: incomplete attributes for ", source_url)
+                continue
+
             lots.append(
                 LotData(
                     timestamp=timestamp,
-                    id=name_to_legacy_id("wiesbaden", attributes["Name"]),
-                    status=self.STATUS_MAPPING.get(attributes["Status"], LotData.Status.unknown),
-                    num_occupied=int_or_none(attributes["Belegt"]),
-                    capacity=int_or_none(attributes["Parkplätze"]),
+                    id=name_to_legacy_id("wiesbaden", attributes["name"]),
+                    status=self.STATUS_MAPPING.get(attributes["status"], LotData.Status.unknown),
+                    num_free=int_or_none(attributes["num_free"]),
+                    capacity=int_or_none(attributes["capacity"]),
                 )
             )
 
         return lots
 
     def iter_lot_attributes(self) -> Generator[Tuple[datetime.datetime, str, dict], None, None]:
-        for url_params in self.LOT_URL_PARAMS:
-            source_url = self.POOL.source_url + url_params
+        soup = self.request_soup(self.POOL.source_url)
+        for row in soup.find_all("tr"):
+            tds = row.find_all("td")
 
-            timestamp = self.now()
-            soup = self.request_soup(source_url, encoding="utf-8")
+            if tds[0].find("h4"):
+                # skip heading
+                continue
 
+            name = tds[0].text.strip()
+            num_free = tds[1].text.split('/')[0].strip()
+            capacity = tds[1].text.split('/')[1].strip()
+            status = tds[3].text.strip()
             attributes = {
-                tr.find_all("td")[0].text.rstrip(":"): tr.find_all("td")[1].text
-                for tr in soup.find_all("tr")
+                "name": name, 
+                "num_free": num_free, 
+                "capacity": capacity, 
+                "status": status
             }
-            if attributes:
-                yield timestamp, source_url, attributes
+            
+            yield self.POOL.source_url, attributes
 
     def get_lot_infos(self) -> List[LotInfo]:
+        
+        lot_map = {
+            lot.id: lot
+            for lot in self.get_v1_lot_infos_from_geojson("Wiesbaden")
+        }
+        
+        lots = []
+        for source_url, attributes in self.iter_lot_attributes():
+            name = attributes["name"]
+            legacy_id = self.name_to_legacy_id(name)
+
+            kwargs = vars(lot_map[legacy_id]) if legacy_id in lot_map else {}
+            kwargs.update(dict(
+                name=name,
+                id=legacy_id,
+                has_live_capacity=True,
+                source_url=source_url,
+            ))
+
+            lots.append(LotInfo(**kwargs))
+
+        return lots
+
+    def name_to_legacy_id(self, name):
         NEW_TO_LEGACY = {
             "Mauritius Galerie": "Mauritius-Parkhaus",
             "City 1": "City I",
             "City 2": "City II",
         }
-        lot_map = {
-            lot.name: lot
-            for lot in self.get_v1_lot_infos_from_geojson("Wiesbaden")
-        }
-        lots = []
-
-        for timestamp, source_url, attributes in self.iter_lot_attributes():
-            legacy_name = attributes["Name"][3:].replace("ss", "ß")
-            legacy_name = NEW_TO_LEGACY.get(legacy_name, legacy_name)
-            kwargs = vars(lot_map[legacy_name])
-            kwargs.update(dict(
-                name=attributes["Name"],
-                id=name_to_legacy_id("wiesbaden", attributes["Name"]),
-                has_live_capacity=True,
-                source_url=source_url,
-            ))
-            lots.append(LotInfo(**kwargs))
-
-        return lots
+        legacy_name = NEW_TO_LEGACY.get(name, name)
+        return name_to_legacy_id(self.POOL.id, name)

--- a/util/strings.py
+++ b/util/strings.py
@@ -20,6 +20,8 @@ def guess_lot_type(name: str) -> Optional[str]:
         "parklevel": LotInfo.Types.level,
         "garage": LotInfo.Types.garage,
         "straßenrand": LotInfo.Types.street,
+        "ph ": LotInfo.Types.garage,
+        "tg ": LotInfo.Types.underground,
     }
 
     name = name.lower()


### PR DESCRIPTION
This PR updates the Wiesbaden scraper and geojson:

* The public_url has moved to https://www.wiesbaden.de/leben-in-wiesbaden/verkehr/auto/parken/parkhaeuser.php
* Parking lot "PH Galeria Kaufhof" was added
* scraping was failing, as `Status` has been moved from a `td` to a `th/h3`
* additionally, the `PH Luisenforum` request is currently failing (see screenshot below). I informed the Imprint contact who forwarded the issue to the responsible person. The scraper is now a bit more robust and ignores such issues.

![grafik](https://user-images.githubusercontent.com/2187389/233700522-e7ec24fe-c198-4b98-8c94-ba27369764c1.png)
