### PR TITLE
Hanau: fix urls and update geojson

### DIFF
--- a/original/hanau.geojson
+++ b/original/hanau.geojson
@@ -27,10 +27,10 @@
         "id": "hanauparkhauscitycenter",
         "name": "Parkhaus City Center",
         "type": "garage",
-        "public_url": "https://www.google.de/maps/place/APCOA+Parkhaus+City+Center/@50.1308625,8.921564,18z/data=!4m11!1m8!2m7!1sparkhaus+city+center+hanau!3m5!1sparkhaus+city+center+hanau!2s50.131,+8.9222!4m2!1d8.9221673!2d50.1309612!3m1!1s0x0000000000000000:0x08eb2e7c2b3120a1?hl=de",
+        "public_url": "https://www.apcoa.de/parken/hanau/city-center/",
         "source_url": null,
         "address": "Kurt-Blaum-Platz 8",
-        "capacity": 246,
+        "capacity": 526,
         "has_live_capacity": true
       },
       "geometry": {

--- a/original/hanau.py
+++ b/original/hanau.py
@@ -12,8 +12,8 @@ class Hanau(ScraperBase):
     POOL = PoolInfo(
         id="hanau",
         name="Hanau",
-        public_url="https://erleben.hanau.de/reise/parken/index.html",
-        source_url="https://erleben.hanau.de/reise/parken/072752/index.html",
+        public_url="https://parken-hanau.de/",
+        source_url="https://parken-hanau.de/",
         timezone="Europe/Berlin",
         attribution_contributor="Stadt Hanau",
         attribution_license=None,
@@ -46,7 +46,7 @@ class Hanau(ScraperBase):
 
         parking_data = soup.find('div', class_='container-fluid')
         last_updated = self.to_utc_datetime(parking_data.find('h5').text, 'Letzte Aktualisierung: %d.%m.%Y %H:%M:%S')
-
+        
         for one_parking_lot in parking_data.find_all('div', class_='well'):
             parking_name = self.normalize_lot_name(one_parking_lot.find('b').text.strip())
 


### PR DESCRIPTION
This PR fixes public_url/source_url for the (apparently just moved) Hanau parking website.

Besides this, it updates the public_url and capacity of Hanau Parkhaus City-Center.