### PR TITLE
Luebeck: fixes unexpectedly closed parking lot

### DIFF
--- a/original/luebeck.py
+++ b/original/luebeck.py
@@ -34,6 +34,43 @@ class Luebeck(ScraperBase):
     )
 
     def get_lot_data(self) -> List[LotData]:
+        """
+        Expects lot data in a structure like the following:
+
+        <div class="location-list--item info-18 location list item list-Parkplatz Straßenrand list-PPS" data-location-uid="18" data-lat="53.86631000" data-lng="10.67123000" data-art="Parkplatz Straßenrand" data-city="Lübeck" data-title="Am Bahnhof / Handelshof - Parkplatz Straßenrand" data-live="" data-plz="23558 "> 
+            <div class="location-list-inner"> 
+                <header> 
+                    <div class="header"> 
+                        <a title="Parkplatz Straßenrand" rel="location-id-18" href="/detail/pps-am-bahnhof-handelshof/"> 
+                            <span class="location-list-item" data-art="Parkplatz Straßenrand"> 
+                                <span class="header h4 name loocation--name">Am Bahnhof / Handelshof</span> | 
+                                <span>Parkplatz Straßenrand</span> 
+                            </span> 
+                        </a> 
+                    </div> 
+                </header> 
+                <div class="location--data" style="display: none;"> 
+                    <span class="name">Am Bahnhof / Handelshof </span>
+                    <span class="art">Parkplatz Straßenrand</span>
+                    <span class="city">Lübeck</span> 
+                </div> 
+                <div class="location--info"> 
+                    <span class="opening">durchgehend</span> 
+                    <div class="services"> 
+                        <span class="service-7" title="MWST frei"></span> 
+                        <span class="phoneparking" title="Handyparken"></span> 
+                        <span class="logo-kwl"></span> 
+                    </div>
+                </div> 
+            </div> 
+            <div class="location--availability-info"> 
+                <div class="data-live-error">Keine Live-Daten verfügbar <br />
+                    <span class="free-spots">/ 12</span>
+                </div> 
+            </div> 
+        </div> 
+        """
+
         timestamp = self.now()
         soup = self.request_soup(self.POOL.public_url)
 
@@ -44,13 +81,19 @@ class Luebeck(ScraperBase):
             if not free_tag:
                 continue
 
-            num_free = int_or_none(free_tag.text)
-            capacity = int_or_none(lot_tag.find("div", class_="free-spots").text.strip("/ "))
             lot_name = lot_tag["data-title"].split(" - ", 1)[0]
-            status = LotData.Status.open
+            free_spots_tag = lot_tag.find("div", class_="free-spots")
+            if not free_spots_tag:
+                status = LotData.Status.closed
+                num_free = 0
+                capacity = 0
+            else:    
+                num_free = int_or_none(free_tag.text)
+                capacity = int_or_none(lot_tag.find("div", class_="free-spots").text.strip("/ "))
+                status = LotData.Status.open
 
-            if num_free is None:
-                status = LotData.Status.nodata
+                if num_free is None:
+                    status = LotData.Status.nodata
 
             lots.append(
                 LotData(


### PR DESCRIPTION
This PR fixes the Lübeck scraper, which failed as div with classname `free-spots` was missing as parking is closed.