### PR TITLE
Muenster: update scraper and geojson

### DIFF
--- a/original/muenster.geojson
+++ b/original/muenster.geojson
@@ -7,17 +7,17 @@
         "id": "muensterbusparkplatz",
         "name": "Busparkplatz",
         "type": "bus",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/4",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/4.html",
         "source_url": null,
         "address": null,
         "capacity": 63,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.616792,
-          51.965429
+          7.616802,
+          51.965714
         ]
       }
     },
@@ -25,19 +25,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphaegidii",
-        "name": "PH Aegidii",
+        "name": "Aegidii",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/7",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/7.html",
         "source_url": null,
         "address": null,
-        "capacity": 780,
-        "has_live_capacity": false
+        "capacity": 750,
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.622396,
-          51.960839
+          7.623031,
+          51.960467
         ]
       }
     },
@@ -45,19 +45,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphaltersteinweg",
-        "name": "PH Alter Steinweg",
+        "name": "Alter Steinweg",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/3",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/3.html",
         "source_url": null,
         "address": null,
-        "capacity": 350,
-        "has_live_capacity": false
+        "capacity": 390,
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.632326,
-          51.962245
+          7.632387,
+          51.962337
         ]
       }
     },
@@ -65,19 +65,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphbahnhofstrasse",
-        "name": "PH Bahnhofstraße",
+        "name": "Bahnhofstraße",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/14",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/14.html",
         "source_url": null,
         "address": null,
-        "capacity": 339,
-        "has_live_capacity": false
+        "capacity": 311,
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.632764,
-          51.955504
+          7.632952,
+          51.955234
         ]
       }
     },
@@ -85,19 +85,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphbremerplatz",
-        "name": "PH Bremer Platz",
+        "name": "Bremer Platz",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/12",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/12.html",
         "source_url": null,
         "address": null,
-        "capacity": 416,
-        "has_live_capacity": false
+        "capacity": 354,
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.637701,
-          51.957459
+          7.637656,
+          51.95794
         ]
       }
     },
@@ -105,19 +105,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphcineplex",
-        "name": "PH Cineplex",
+        "name": "Cineplex",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/15",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/15.html",
         "source_url": null,
         "address": null,
         "capacity": 590,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.635975,
-          51.949828
+          7.636025,
+          51.949832
         ]
       }
     },
@@ -125,19 +125,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphengelenschanze",
-        "name": "PH Engelenschanze",
+        "name": "Engelenschanze",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/13",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/13.html",
         "source_url": null,
         "address": null,
         "capacity": 480,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.631493,
-          51.955674
+          7.631394,
+          51.955746
         ]
       }
     },
@@ -145,19 +145,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphkarstadt",
-        "name": "PH Karstadt",
+        "name": "Karstadt",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/10",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/10.html",
         "source_url": null,
         "address": null,
         "capacity": 183,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.629907,
-          51.960783
+          7.630412,
+          51.961272
         ]
       }
     },
@@ -165,19 +165,59 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphmuensterarkaden",
-        "name": "PH Münster Arkaden",
+        "name": "Münster-Arkaden",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/9",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/9.html",
         "source_url": null,
         "address": null,
-        "capacity": 248,
-        "has_live_capacity": false
+        "capacity": 150,
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.626499,
-          51.959854
+          7.626485,
+          51.959779
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "muensterphphcoesfelderkreuz",
+        "name": "PH Coesfelder Kreuz",
+        "type": "garage",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/17.html",
+        "source_url": null,
+        "address": null,
+        "capacity": 869,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -19.442876,
+          48.340295
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "muensterphphstadthaus3",
+        "name": "PH Stadthaus 3",
+        "type": "garage",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/16.html",
+        "source_url": null,
+        "address": null,
+        "capacity": 372,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.640941,
+          51.949368
         ]
       }
     },
@@ -185,19 +225,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphstubengasse",
-        "name": "PH Stubengasse",
+        "name": "Stubengasse",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/11",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/11.html",
         "source_url": null,
         "address": null,
         "capacity": 318,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.630287,
-          51.959884
+          7.629795,
+          51.960033
         ]
       }
     },
@@ -205,19 +245,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterphtheater",
-        "name": "PH Theater",
+        "name": "Theater",
         "type": "garage",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/1",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/1.html",
         "source_url": null,
         "address": null,
-        "capacity": 793,
-        "has_live_capacity": false
+        "capacity": 748,
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.626454,
-          51.965676
+          7.62679,
+          51.965993
         ]
       }
     },
@@ -225,19 +265,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterppgeorgskommende",
-        "name": "PP Georgskommende",
+        "name": "Georgskommende",
         "type": "lot",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/8",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/8.html",
         "source_url": null,
         "address": null,
         "capacity": 272,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.619322,
-          51.959491
+          7.619173,
+          51.959603
         ]
       }
     },
@@ -245,19 +285,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterpphoersterplatz",
-        "name": "PP Hörsterplatz",
+        "name": "Hörster Platz",
         "type": "lot",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/2",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/2.html",
         "source_url": null,
         "address": null,
         "capacity": 202,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.632232,
-          51.964237
+          7.631689,
+          51.964244
         ]
       }
     },
@@ -265,19 +305,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterppschlossplatznord",
-        "name": "PP Schlossplatz Nord",
+        "name": "Schlossplatz Nord",
         "type": "lot",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/5",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/5.html",
         "source_url": null,
         "address": null,
         "capacity": 450,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.617017,
-          51.964472
+          7.61696,
+          51.964377
         ]
       }
     },
@@ -285,19 +325,19 @@
       "type": "Feature",
       "properties": {
         "id": "muensterppschlossplatzsued",
-        "name": "PP Schlossplatz Süd",
+        "name": "Schlossplatz Süd",
         "type": "lot",
-        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/detailseite/parkhaeuser/detailansicht/parkhaus/6",
+        "public_url": "https://www.stadt-muenster.de/tiefbauamt/parkleitsystem/parkhaeuser/detailansicht/parkhaus/6.html",
         "source_url": null,
         "address": null,
         "capacity": 460,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          7.6167,
-          51.962386
+          7.61685,
+          51.962749
         ]
       }
     }

--- a/original/muenster.py
+++ b/original/muenster.py
@@ -15,8 +15,9 @@ class Muenster(ScraperBase):
         public_url="https://www.stadt-muenster.de/tiefbauamt/parkleitsystem",
         source_url="https://api.dashboard.smartcity.ms/parking",
         timezone="Europe/Berlin",
-        attribution_contributor="Amt für Mobilität und Tiefbau Münster",
-        attribution_license=None,
+        attribution_contributor="dl-by-de/2.0",
+        attribution_license="Stadt Münster",
+        # see also https://opendata.stadt-muenster.de/dataset/parkleitsystem-parkhausbelegung-aktuell
         attribution_url="https://www.stadt-muenster.de/tiefbauamt/impressum.html",
     )
 


### PR DESCRIPTION
This PR updates muenster scraper and geojson.

i.e., 
* it includes the table, as it's exclusion skippe the last parking
* in `muenster.get_lot_infos` adds minimally required lot info for yet unknown parking lots
* it adds missing parking lots to the geojson
* updates manually set capacity and has_live_data