### PR TITLE
Mannheim: update scraper and geojson

### DIFF
--- a/original/mannheim.geojson
+++ b/original/mannheim.geojson
@@ -11,7 +11,7 @@
         "source_url": null,
         "address": "C1,13-15",
         "capacity": 211,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -31,7 +31,7 @@
         "source_url": null,
         "address": "Cahn-Garnier-Ufer",
         "capacity": 213,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -51,7 +51,7 @@
         "source_url": null,
         "address": "Collini-Str. 1",
         "capacity": 650,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -71,7 +71,7 @@
         "source_url": null,
         "address": "D3, 5",
         "capacity": 378,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -91,7 +91,7 @@
         "source_url": null,
         "address": "Freistuhl 5",
         "capacity": 365,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -111,7 +111,7 @@
         "source_url": null,
         "address": "D5",
         "capacity": 337,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -131,7 +131,7 @@
         "source_url": null,
         "address": "H6 (Swanseaplatz)",
         "capacity": 271,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -151,7 +151,7 @@
         "source_url": null,
         "address": "Willy-Brandt-Platz 5",
         "capacity": 327,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -171,7 +171,7 @@
         "source_url": null,
         "address": "Heinrich-von-Stephan-Str. 6",
         "capacity": 326,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -185,13 +185,13 @@
       "type": "Feature",
       "properties": {
         "id": "mannheimhauptbahnhofp3p4parkhaus",
-        "name": "Hauptbahnhof P3/P4, Parkhaus",
+        "name": "Hauptbahnhof P3, Parkhaus",
         "type": "garage",
         "public_url": "https://www.parken-mannheim.de/p/HBFP3",
         "source_url": null,
         "address": "Kepler-Str. 21-25",
         "capacity": 264,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -211,7 +211,7 @@
         "source_url": null,
         "address": "Kolpingstraße 2",
         "capacity": 584,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -231,7 +231,7 @@
         "source_url": null,
         "address": "Theodor-Kutzer-Ufer",
         "capacity": 313,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -251,7 +251,7 @@
         "source_url": null,
         "address": "Theodor-Kutzer-Ufer",
         "capacity": 509,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -271,7 +271,7 @@
         "source_url": null,
         "address": "Friedrichsplatz 5a",
         "capacity": 406,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -291,7 +291,7 @@
         "source_url": null,
         "address": "M4a",
         "capacity": 68,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -311,7 +311,7 @@
         "source_url": null,
         "address": "N1,3",
         "capacity": 441,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -331,7 +331,7 @@
         "source_url": null,
         "address": "N6, 3",
         "capacity": 201,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -351,33 +351,13 @@
         "source_url": null,
         "address": "N6, 3",
         "capacity": 298,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
           8.469266,
           49.484904
-        ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "id": "mannheimnationaltheater",
-        "name": "Nationaltheater",
-        "type": "lot",
-        "public_url": "https://www.parken-mannheim.de/p/9dfdcf84-3e67-4747-905f-b4b6c7c97c93",
-        "source_url": null,
-        "address": "Hebelstraße",
-        "capacity": 160,
-        "has_live_capacity": false
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.479093,
-          49.488723
         ]
       }
     },
@@ -391,7 +371,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 348,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -411,7 +391,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 815,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -431,7 +411,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 850,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -451,7 +431,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 1520,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
@@ -471,7 +451,7 @@
         "source_url": null,
         "address": "U2 (Herschelplatz)",
         "capacity": 190,
-        "has_live_capacity": false
+        "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",

--- a/original/mannheim.geojson
+++ b/original/mannheim.geojson
@@ -11,7 +11,7 @@
         "source_url": null,
         "address": "C1,13-15",
         "capacity": 211,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -31,7 +31,7 @@
         "source_url": null,
         "address": "Cahn-Garnier-Ufer",
         "capacity": 213,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -51,7 +51,7 @@
         "source_url": null,
         "address": "Collini-Str. 1",
         "capacity": 650,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -71,7 +71,7 @@
         "source_url": null,
         "address": "D3, 5",
         "capacity": 378,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -91,7 +91,7 @@
         "source_url": null,
         "address": "Freistuhl 5",
         "capacity": 365,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -111,7 +111,7 @@
         "source_url": null,
         "address": "D5",
         "capacity": 337,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -131,7 +131,7 @@
         "source_url": null,
         "address": "H6 (Swanseaplatz)",
         "capacity": 271,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -151,7 +151,7 @@
         "source_url": null,
         "address": "Willy-Brandt-Platz 5",
         "capacity": 327,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -171,7 +171,7 @@
         "source_url": null,
         "address": "Heinrich-von-Stephan-Str. 6",
         "capacity": 326,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -191,7 +191,7 @@
         "source_url": null,
         "address": "Kepler-Str. 21-25",
         "capacity": 264,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -211,7 +211,7 @@
         "source_url": null,
         "address": "Kolpingstraße 2",
         "capacity": 584,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -231,7 +231,7 @@
         "source_url": null,
         "address": "Theodor-Kutzer-Ufer",
         "capacity": 313,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -251,7 +251,7 @@
         "source_url": null,
         "address": "Theodor-Kutzer-Ufer",
         "capacity": 509,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -271,7 +271,7 @@
         "source_url": null,
         "address": "Friedrichsplatz 5a",
         "capacity": 406,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -291,7 +291,7 @@
         "source_url": null,
         "address": "M4a",
         "capacity": 68,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -311,7 +311,7 @@
         "source_url": null,
         "address": "N1,3",
         "capacity": 441,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -331,7 +331,7 @@
         "source_url": null,
         "address": "N6, 3",
         "capacity": 201,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -351,7 +351,7 @@
         "source_url": null,
         "address": "N6, 3",
         "capacity": 298,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -371,7 +371,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 348,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -391,7 +391,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 815,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -411,7 +411,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 850,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -431,7 +431,7 @@
         "source_url": null,
         "address": "Xaver-Fuhr-Straße 152",
         "capacity": 1520,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -451,7 +451,7 @@
         "source_url": null,
         "address": "U2 (Herschelplatz)",
         "capacity": 190,
-        "has_live_capacity": true
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",

--- a/original/mannheim.py
+++ b/original/mannheim.py
@@ -107,7 +107,6 @@ class Mannheim(ScraperBase):
             kwargs.update(dict(
                 id=lot_id,
                 name=parking_name,
-                has_live_capacity=True,
                 public_url=urllib.parse.urljoin(self.POOL.public_url, link["href"])
             ))
 

--- a/original/mannheim.py
+++ b/original/mannheim.py
@@ -20,6 +20,14 @@ class Mannheim(ScraperBase):
         attribution_url="https://www.parken-mannheim.de/impressum",
     )
 
+    """
+    Maps current parking lot names to their former name to provide
+    backward compatibility.
+    """
+    LOT_LEGACY_NAME_MAPPINGS = {
+        "Hauptbahnhof P3, Parkhaus": "Hauptbahnhof P3/P4 Parkhaus",
+    }
+
     def get_lot_data(self) -> List[LotData]:
         timestamp = self.now()
         soup = self.request_soup(self.POOL.public_url)
@@ -27,6 +35,7 @@ class Mannheim(ScraperBase):
         lots = []
 
         # suche: <div id="parkhausliste-ct">
+        # Note: page contains two elements with id parkhausliste-ct, the last one contains the lot data
         div_level1 = soup.find_all('div', id='parkhausliste-ct')[-1]
         # <p style="color: #7a7a7b; padding: 18px 0 8px 0">zuletzt aktualisiert am 19.06.2019, 15:27 Uhr</p>
         date_time = div_level1.find('p')
@@ -39,6 +48,11 @@ class Mannheim(ScraperBase):
         while count < len(div_level3) - 2:
             parking_name = div_level3[count+1].text.strip()
 
+            if parking_name in ('P20', 'UEG (Funktionskarten)'):
+                # workaround: ignore entries which seem to be no parking lots
+                count += 3
+                continue
+            
             parking_free = None
             parking_state = LotData.Status.open
             try:
@@ -51,7 +65,7 @@ class Mannheim(ScraperBase):
             lots.append(
                 LotData(
                     timestamp=timestamp,
-                    id=name_to_legacy_id("mannheim", parking_name),
+                    id=self.name_to_legacy_id(parking_name),
                     lot_timestamp=last_updated,
                     status=parking_state,
                     num_free=parking_free,
@@ -62,7 +76,7 @@ class Mannheim(ScraperBase):
 
     def get_lot_infos(self) -> List[LotInfo]:
         lot_map = {
-            lot.name: lot
+            lot.id: lot
             for lot in self.get_v1_lot_infos_from_geojson("Mannheim")
         }
 
@@ -78,14 +92,30 @@ class Mannheim(ScraperBase):
         count = 0
         while count < len(div_level3) - 2:
             parking_name = div_level3[count+1].text.strip()
+
+            if parking_name in ('P20', 'UEG (Funktionskarten)'):
+                # workaround: ignore entries which seem to be no parking lots
+                count += 3
+                continue
+            
+            lot_id = self.name_to_legacy_id(parking_name)
+
             link = div_level3[count+1].find("a")
             count += 3
             
-            kwargs = vars(lot_map[parking_name])
+            kwargs = vars(lot_map[lot_id]) if lot_id in lot_map else {}
             kwargs.update(dict(
+                id=lot_id,
+                name=parking_name,
+                has_live_capacity=True,
                 public_url=urllib.parse.urljoin(self.POOL.public_url, link["href"])
             ))
 
             lots.append(LotInfo(**kwargs))
 
         return lots
+
+    def name_to_legacy_id(self, lot_name) -> str:
+        legacy_name = self.LOT_LEGACY_NAME_MAPPINGS.get(lot_name, lot_name)
+        return name_to_legacy_id(self.POOL.id, legacy_name)
+


### PR DESCRIPTION
This PR updates `mannheim` scraper and geojson.

i.e.

* it excludes apparently invalid parkings from the results
* it updates `has_live_capacity` information
* it removes no longer existing parking `Nationaltheater`
* it maps `Hauptbahnhof P3 Parkhaus` to legacy `Hauptbahnhof P3/P4, Parkhaus` to keep the history and data
