### PR TITLE
Fix heidelberg issues

### DIFF
--- a/original/heidelberg.geojson
+++ b/original/heidelberg.geojson
@@ -147,7 +147,7 @@
         "id": "heidelbergp16nordbrueckenkopf",
         "name": "P16 Nordbrückenkopf",
         "type": "garage",
-        "public_url": "https://www.swhd.de/de/Hauptnavigation/Parkhaeuser/Nordbrueckenkopf-P16/",
+        "public_url": "https://www.swhd.de/p16",
         "source_url": null,
         "address": "Uferstraße\n69120 Heidelberg",
         "capacity": 113,
@@ -204,6 +204,26 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "heidelbergp19campbellbarracks",
+        "name": "P19 Campbell Barracks",
+        "type": "garage",
+        "public_url": "https://www.swhd.de/de/Kopfnavigation/Presse/Meldungslisten-SWH/Meldungsliste-SWH-3/Solar-Parkhaus-in-den-Campbell-Barracks.html",
+        "source_url": null,
+        "address": "Nina-Simone-Straße 6\n69126 Heidelberg",
+        "capacity": 1,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.68104,
+          49.38794
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "heidelbergp1poststrasse",
         "name": "P1 Poststraße",
         "type": "underground",
@@ -239,19 +259,6 @@
           8.675042,
           49.418319
         ]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "id": "heidelbergp26kirchheim",
-        "name": "P26 Kirchheim",
-        "type": "garage",
-        "public_url": null,
-        "source_url": null,
-        "address": null,
-        "capacity": 55,
-        "has_live_capacity": true
       }
     },
     {

--- a/original/heidelberg.geojson
+++ b/original/heidelberg.geojson
@@ -10,7 +10,7 @@
         "public_url": null,
         "source_url": null,
         "address": "Schneidmühlstraße 5\n69115 Heidelberg",
-        "capacity": 38,
+        "capacity": 39,
         "has_live_capacity": true
       },
       "geometry": {
@@ -30,7 +30,7 @@
         "public_url": "http://www.heidelberger-stadtwerke.de/cms/Garagen/Parkhaus_Friedrich-Ebert-Platz/Parkhaus_Friedrich-Ebert-Platz.html",
         "source_url": null,
         "address": "Friedrich-Ebert-Platz\n69117 Heidelberg",
-        "capacity": 122,
+        "capacity": 121,
         "has_live_capacity": true
       },
       "geometry": {
@@ -70,7 +70,7 @@
         "public_url": "http://www.swhd.de/cms/Garagen/Parkhaus_Kornmarkt_Schloss/Parkhaus_Kornmarkt_Schloss.html",
         "source_url": null,
         "address": "Neue Schlossstraße\n69117 Heidelberg",
-        "capacity": 150,
+        "capacity": 158,
         "has_live_capacity": true
       },
       "geometry": {
@@ -130,7 +130,7 @@
         "public_url": "http://www.pbw.de/",
         "source_url": null,
         "address": "Thibautstr. 1A\n69115 Heidelberg",
-        "capacity": 175,
+        "capacity": 150,
         "has_live_capacity": true
       },
       "geometry": {
@@ -150,7 +150,7 @@
         "public_url": "https://www.swhd.de/de/Hauptnavigation/Parkhaeuser/Nordbrueckenkopf-P16/",
         "source_url": null,
         "address": "Uferstraße\n69120 Heidelberg",
-        "capacity": 120,
+        "capacity": 113,
         "has_live_capacity": true
       },
       "geometry": {
@@ -230,7 +230,7 @@
         "public_url": null,
         "source_url": null,
         "address": "Berliner Straße 41-49\n69120 Heidelberg",
-        "capacity": 177,
+        "capacity": 160,
         "has_live_capacity": true
       },
       "geometry": {
@@ -323,7 +323,7 @@
         "public_url": "http://www.swhd.de/cms/Garagen/Parkhaus_Kraus/Parkhaus_Kraus.html",
         "source_url": null,
         "address": "Untere Neckarstraße 2\n69117 Heidelberg",
-        "capacity": 141,
+        "capacity": 155,
         "has_live_capacity": true
       },
       "geometry": {
@@ -383,7 +383,7 @@
         "public_url": "http://www.apcoa.de/",
         "source_url": null,
         "address": "Friedrich-Ebert-Anlage 51c\n69117 Heidelberg",
-        "capacity": 160,
+        "capacity": 310,
         "has_live_capacity": true
       },
       "geometry": {

--- a/original/heidelberg.py
+++ b/original/heidelberg.py
@@ -5,6 +5,7 @@ from typing import List
 
 from util import *
 
+import warnings
 
 class Heidelberg(ScraperBase):
 
@@ -25,6 +26,13 @@ class Heidelberg(ScraperBase):
         "Referer": "https://parken.heidelberg.de/",
     }
 
+    def _should_ignore(self, parking_lot):
+        if parking_lot['uid'] == '26':
+            warnings.warn(f'Ignoring heidelbergp26kirchheim, as it has non static information')
+            return True
+        
+        return False
+
     def get_lot_data(self) -> List[LotData]:
         timestamp = self.now()
         dataJSON = self.request_json(self.POOL.source_url)
@@ -36,7 +44,12 @@ class Heidelberg(ScraperBase):
         for parking_lot in dataJSON['data']['parkinglocations'] :
             # please keep the name in the geojson-file in the same form as delivered here (including spaces)
             parking_name = ('P'+str(parking_lot['uid'])+' '+parking_lot['name']).strip()
+            parking_id = name_to_legacy_id(self.POOL.id, parking_name)
 
+            # Note: 
+            if self._should_ignore(parking_lot):
+                continue
+            
             try:
                 parking_capacity = int(parking_lot['parkingupdate']['total'])
                 parking_occupied = int(parking_lot['parkingupdate']['current'])
@@ -57,7 +70,7 @@ class Heidelberg(ScraperBase):
                 LotData(
                     timestamp=timestamp,
                     lot_timestamp=last_updated,
-                    id=name_to_legacy_id("heidelberg", parking_name),
+                    id=parking_id,
                     status=parking_state,
                     num_occupied=parking_occupied,
                     capacity=parking_capacity,
@@ -88,17 +101,30 @@ class Heidelberg(ScraperBase):
 
             original_lot = vars(lot_map.get(lot_id)) if lot_id in lot_map else {}
 
+            parking_id = name_to_legacy_id(self.POOL.id, parking_name)
+
+            lat = original_lot.get("latitude")
+            lon = original_lot.get("longitude")
+            if lat is None or lon is None:
+                # Note: the original ParkAPIv1 json had no coords, we explicitly set them here for no
+                if parking_id == 'heidelbergp19campbellbarracks':
+                    lat = 49.38794
+                    lon = 8.68104
+                else:
+                    warnings.warn(f"Lot '{parking_id}' has no coords. Skipping")
+                    continue
+
             lots.append(
                 LotInfo(
-                    id=name_to_legacy_id(self.POOL.id, parking_name),
+                    id=parking_id,
                     type=original_lot.get("type") or 'garage',
                     name=parking_name,
                     capacity=parking_capacity,
                     public_url=parking_lot.get("website"),
                     has_live_capacity=True,
                     address=parking_lot["address"].replace(" ,", ",").strip(" ,").replace(", ", "\n"),
-                    latitude=original_lot.get("latitude"),
-                    longitude=original_lot.get("longitude"),
+                    latitude=lat,
+                    longitude=lon,
                 )
             )
 


### PR DESCRIPTION
This PR does some minor data updates/fixes:

- p26 is removed as no further information for it is available on the cities homepage
- p19 is (re)added with an explicitly set coord (was not defined in ParkAPIv1)
- some capacities are updated with their current values
- two urls are manuallly updated

Remaining issues for this pool: No attribution and no license:

```sh
% python scraper.py validate -p heidelberg
  warnings.warn(
2023-10-10 23:51:21.010427 scraping pool 'heidelberg'
2023-10-10 23:51:21.011311 requesting GET https://parken.heidelberg.de/v1/parking-location?key=3wU8F-5QycD-ZbaW9-R6uvj-xm1MG-X07ne
...ParkAPI2-sources/original/heidelberg.py:31: UserWarning: Ignoring heidelbergp26kirchheim, as it has no static information
  warnings.warn(f'Ignoring heidelbergp26kirchheim, as it has no static information')
[
  {
    "pool_id": "heidelberg",
    "validation": {
      "path": "pool.attribution_license",
      "message": "Pool 'heidelberg' should have 'attribution_license'",
      "priority": 3
    }
  },
  {
    "pool_id": "heidelberg",
    "validation": {
      "path": "pool.attribution_url",
      "message": "Pool 'heidelberg' should have 'attribution_url'",
      "priority": 3
    }
  }
]
```