### PR TITLE
change util import to relative fir using sources as git submodule

### DIFF
--- a/new/bahn.py
+++ b/new/bahn.py
@@ -11,7 +11,7 @@ from typing import List
 
 from decouple import config
 
-from util import *
+from ..util import *
 
 BAHN_API_TOKEN = config("BAHN_API_TOKEN", None)
 

--- a/new/bielefeld.py
+++ b/new/bielefeld.py
@@ -2,7 +2,7 @@ import re
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Bielefeld(ScraperBase):

--- a/new/bochum.py
+++ b/new/bochum.py
@@ -1,7 +1,7 @@
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Bochum(ScraperBase):

--- a/new/braunschweig.py
+++ b/new/braunschweig.py
@@ -3,7 +3,7 @@ from typing import List
 
 import bs4
 
-from util import *
+from ..util import *
 
 
 class Braunschweig(ScraperBase):

--- a/new/jena.py
+++ b/new/jena.py
@@ -1,7 +1,7 @@
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Jena(ScraperBase):

--- a/original/aarhus.py
+++ b/original/aarhus.py
@@ -3,7 +3,7 @@ Original code and data by Ciosici
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Aarhus(ScraperBase):

--- a/original/apag.py
+++ b/original/apag.py
@@ -3,7 +3,7 @@ Original code by Quint, Berke
 """
 from typing import List, Tuple, Generator
 
-from util import *
+from ..util import *
 
 import bs4
 import re

--- a/original/basel.py
+++ b/original/basel.py
@@ -6,7 +6,7 @@ from typing import List, Tuple, Union, Optional
 
 import feedparser
 
-from util import *
+from ..util import *
 
 
 class Basel(ScraperBase):

--- a/original/bonn.py
+++ b/original/bonn.py
@@ -9,7 +9,7 @@ from typing import List, Tuple, Generator
 
 import bs4
 
-from util import *
+from ..util import *
 
 
 class Bonn(ScraperBase):

--- a/original/dortmund.py
+++ b/original/dortmund.py
@@ -5,7 +5,7 @@ import re
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Dortmund(ScraperBase):

--- a/original/dresden.py
+++ b/original/dresden.py
@@ -4,7 +4,7 @@ Original code by Kliemann
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Dresden(ScraperBase):

--- a/original/frankfurt.py
+++ b/original/frankfurt.py
@@ -3,7 +3,7 @@ Original code by Romankov
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Frankfurt(ScraperBase):

--- a/original/freiburg.py
+++ b/original/freiburg.py
@@ -3,7 +3,7 @@ Original code and data by Wieland
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Dortmund(ScraperBase):

--- a/original/hamburg.py
+++ b/original/hamburg.py
@@ -7,7 +7,7 @@ import datetime
 import utm
 
 
-from util import *
+from ..util import *
 
 
 class Hamburg(ScraperBase):

--- a/original/hanau.py
+++ b/original/hanau.py
@@ -4,7 +4,7 @@ Original code and data by Quint
 import warnings
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Hanau(ScraperBase):

--- a/original/heidelberg.py
+++ b/original/heidelberg.py
@@ -3,7 +3,7 @@ Original code and data by Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 import warnings
 

--- a/original/heilbronn.py
+++ b/original/heilbronn.py
@@ -3,7 +3,7 @@ Original code and data by Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Heilbronn(ScraperBase):

--- a/original/ingolstadt.py
+++ b/original/ingolstadt.py
@@ -3,7 +3,7 @@ Original code and data by Költzsch, Thalheim
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Ingolstadt(ScraperBase):

--- a/original/kaiserslautern.py
+++ b/original/kaiserslautern.py
@@ -4,7 +4,7 @@ Original code and data by nicomue7
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Kaiserslautern(ScraperBase):

--- a/original/karlsruhe.py
+++ b/original/karlsruhe.py
@@ -7,7 +7,7 @@ from typing import List, Tuple, Generator, Optional
 
 import bs4
 
-from util import *
+from ..util import *
 
 
 class Karlsruhe(ScraperBase):

--- a/original/koeln.py
+++ b/original/koeln.py
@@ -6,7 +6,7 @@ from typing import List
 
 import bs4
 
-from util import *
+from ..util import *
 
 
 class Koeln(ScraperBase):

--- a/original/konstanz.py
+++ b/original/konstanz.py
@@ -4,7 +4,7 @@ Original code and data by Woltmann, Quint, Koeltzsch,
 import urllib.parse
 from typing import List, Tuple, Generator
 
-from util import *
+from ..util import *
 
 
 class Konstanz(ScraperBase):

--- a/original/limburg.py
+++ b/original/limburg.py
@@ -3,7 +3,7 @@ Original code and data by Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Limburg(ScraperBase):

--- a/original/luebeck.py
+++ b/original/luebeck.py
@@ -17,7 +17,7 @@ The legacy IDs are kept as far as the lot name did not change.
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Luebeck(ScraperBase):

--- a/original/magdeburg.py
+++ b/original/magdeburg.py
@@ -8,7 +8,7 @@ No "Endstelle Diesdorf", "Milchhof" and "Lange Lake" anymore.
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Magdeburg(ScraperBase):

--- a/original/mannheim.py
+++ b/original/mannheim.py
@@ -4,7 +4,7 @@ Original code and data by Quint
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Mannheim(ScraperBase):

--- a/original/muenster.py
+++ b/original/muenster.py
@@ -4,7 +4,7 @@ Original code and data by Költzsch, Thalheim
 import urllib.parse
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Muenster(ScraperBase):

--- a/original/nuernberg.py
+++ b/original/nuernberg.py
@@ -6,7 +6,7 @@ from typing import List, Tuple, Generator
 
 import bs4
 
-from util import *
+from ..util import *
 
 
 class Nuernberg(ScraperBase):

--- a/original/oldenburg.py
+++ b/original/oldenburg.py
@@ -3,7 +3,7 @@ Original code and data by Thalheim, Tranquillo, Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Oldenburg(ScraperBase):

--- a/original/regensburg.py
+++ b/original/regensburg.py
@@ -3,7 +3,7 @@ Original code and data by Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Regensburg(ScraperBase):

--- a/original/rosenheim.py
+++ b/original/rosenheim.py
@@ -3,7 +3,7 @@ Original code and data by Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Rosenheim(ScraperBase):

--- a/original/ulm.py
+++ b/original/ulm.py
@@ -3,7 +3,7 @@ Original code and data by Quint
 """
 from typing import List
 
-from util import *
+from ..util import *
 
 
 class Ulm(ScraperBase):

--- a/original/wiesbaden.py
+++ b/original/wiesbaden.py
@@ -4,7 +4,7 @@ Original code and data by Quint
 import datetime
 from typing import List, Tuple, Generator
 
-from util import *
+from ..util import *
 
 
 class Wiesbaden(ScraperBase):

--- a/original/zuerich.py
+++ b/original/zuerich.py
@@ -6,7 +6,7 @@ from typing import List, Tuple, Optional
 
 import feedparser
 
-from util import *
+from ..util import *
 
 
 class Zuerich(ScraperBase):


### PR DESCRIPTION
This MR changes the import strategy in order to make it possible to use this repository as a git submodule in a subfolder in another application.