### PR TITLE
extend scraping result lists

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -10,4 +10,4 @@ from .strings import (
 from .snapshot import SnapshotMaker
 from .scraper import ScraperBase
 from .soup import get_soup_text
-from .structs import PoolInfo, LotInfo, LotData
+from .structs import PoolInfo, LotInfo, LotData, LotInfoList, LotDataList

--- a/util/structs.py
+++ b/util/structs.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Union, Optional
+from typing import Union, Optional, List, Iterable
 
 from .strings import guess_lot_type
 
@@ -181,6 +181,22 @@ class LotData(Struct):
                             f", expected {self.capacity - self.num_occupied}"
                             f" (occupied={self.num_occupied}, capacity={self.capacity})"
                         )
+
+
+class LotInfoList(List[LotInfo]):
+    lot_error_count: Optional[int] = None
+
+    def __init__(self, items: Iterable[LotInfo], *, lot_error_count: Optional[int] = None):
+        list.__init__(self, items)
+        self.lot_error_count = lot_error_count
+
+
+class LotDataList(List[LotData]):
+    lot_error_count: Optional[int] = None
+
+    def __init__(self, items: Iterable[LotData], *, lot_error_count: Optional[int] = None):
+        list.__init__(self, items)
+        self.lot_error_count = lot_error_count
 
 
 def validate_timestamp(timestamp: datetime.datetime, parent: str):


### PR DESCRIPTION
In order to give the amount of errors back to any follow-up data handling, this MR introduces extendes lists. They act as normal lists, so they don't conflict with existing code, but have an additional attribute.