### PR TITLE
prevent heilbronn crash

### DIFF
--- a/original/heilbronn.py
+++ b/original/heilbronn.py
@@ -73,8 +73,8 @@ class Heilbronn(ScraperBase):
             for lot in self.get_v1_lot_infos_from_geojson("Heilbronn")
         }
 
-        lots = []
-        error_count = 0
+        lots: list[LotInfo] = []
+        errors: list[str] = []
 
         soup = self.request_soup(self.POOL.source_url)
         parking_lots = soup.find_all( 'div', class_='row carparkContent')
@@ -87,11 +87,11 @@ class Heilbronn(ScraperBase):
                 parking_name = park_temp1.text.strip()
 
             if parking_name not in lot_map:
-                error_count += 1
+                errors.append(f'parking site "{parking_name}" is not in provided GeoJSON')
                 continue
             kwargs = vars(lot_map[parking_name])
             kwargs["public_url"] = park_temp2["href"] if park_temp2 else None
 
             lots.append(LotInfo(**kwargs))
 
-        return LotInfoList(lots, lot_error_count=error_count)
+        return LotInfoList(lots, errors=errors)

--- a/util/structs.py
+++ b/util/structs.py
@@ -184,19 +184,27 @@ class LotData(Struct):
 
 
 class LotInfoList(List[LotInfo]):
-    lot_error_count: Optional[int] = None
+    errors: Optional[list[str]] = None
 
-    def __init__(self, items: Iterable[LotInfo], *, lot_error_count: Optional[int] = None):
+    def __init__(self, items: Iterable[LotInfo], *, errors: Optional[list[str]] = None):
         list.__init__(self, items)
-        self.lot_error_count = lot_error_count
+        self.errors = errors
+
+    @property
+    def error_count(self) -> int:
+        return None if self.errors is None else len(self.errors)
 
 
 class LotDataList(List[LotData]):
-    lot_error_count: Optional[int] = None
+    errors: Optional[list[str]] = None
 
-    def __init__(self, items: Iterable[LotData], *, lot_error_count: Optional[int] = None):
+    def __init__(self, items: Iterable[LotData], *, errors: Optional[list[str]] = None):
         list.__init__(self, items)
-        self.lot_error_count = lot_error_count
+        self.errors = errors
+
+    @property
+    def error_count(self) -> int:
+        return None if self.errors is None else len(self.errors)
 
 
 def validate_timestamp(timestamp: datetime.datetime, parent: str):


### PR DESCRIPTION
Fixes a complete crash at heilbronn if GeoJSON and scraped information have different datasets. Adds error messages to the result, too, in order to use / log them later.