### PR TITLE
fix reutlingen uid typing

### DIFF
--- a/v3/reutlingen.py
+++ b/v3/reutlingen.py
@@ -107,7 +107,7 @@ class ReutlingenConverter(CsvConverter):
                 continue
 
             parking_site_input = StaticParkingSiteInput(
-                uid=input_data.uid,
+                uid=str(input_data.uid),
                 name=input_data.name,
                 address=f'{input_data.name}, Reutlingen',
                 lat=input_data.coordinates[1],


### PR DESCRIPTION
uid is a string, and postgre does not int instead of str as input for a string field