### PR TITLE
Add DATEX2 source for Aachen

### DIFF
--- a/new/aachen.geojson
+++ b/new/aachen.geojson
@@ -1,0 +1,339 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhauseurogress",
+        "name": "P01-Eurogress",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-eurogress",
+        "address": "Monheimsallee 44, 52062 Aachen",
+        "capacity": 560,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.0927987,
+          50.780552
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp10",
+        "name": "P10-Seilgraben",
+        "type": "garage",
+        "public_url": "https://www.mein-contipark.de/parkplatz-finden/parken-in-aachen/parkhaus-grosskoelnstrasse-aachen--ci3cp1124065",
+        "source_url": null,
+        "address": "Seilgraben 45, 52062 Aachen",
+        "capacity": 306,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.0851154,
+          50.778053
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp11",
+        "name": "P11-Lothringer Strasse",
+        "type": "garage",
+        "public_url": "https://www.mein-contipark.de/parkplatz-finden/parken-in-aachen/parkhaus-lothringerstrasse-aachen--ci3cp1124507",
+        "source_url": null,
+        "address": "Lothringerstraße 2-14, 52062 Aachen",
+        "capacity": 349,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.0935435,
+          50.77121
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp12",
+        "name": "P12-Annastrasse",
+        "type": "garage",
+        "public_url": null,
+        "source_url": null,
+        "address": "Annastraße 56, 52062 Aachen",
+        "capacity": 66,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.0803576,
+          50.77292
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp13",
+        "name": "P13-Stiftstrasse",
+        "type": "garage",
+        "public_url": "https://www.q-park.de/de-de/staedte/aachen/stiftstra%C3%9Fe/",
+        "source_url": null,
+        "address": "Stiftstr. 38, 52062 Aachen",
+        "capacity": 0,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.093653,
+          50.7759
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp14",
+        "name": "P14-City Center",
+        "type": "garage",
+        "public_url": null,
+        "source_url": null,
+        "address": "Alexianergraben 9-23, 52062 Aachen",
+        "capacity": 180,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.083549,
+          50.771896
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp15",
+        "name": "P15-Matthiashofstrasse",
+        "type": "garage",
+        "public_url": "https://www.city-parkhaus.de/parkhaus/aachen.php",
+        "source_url": null,
+        "address": "Matthiashofstraße, 52064 Aachen",
+        "capacity": 160,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.083538,
+          50.77099
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp16",
+        "name": "P16-Kapuziner Karree",
+        "type": "garage",
+        "public_url": null,
+        "source_url": null,
+        "address": "Borngasse 30, 52062 Aachen",
+        "capacity": 305,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.088164,
+          50.771523
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp17",
+        "name": "P17-EBV Carre",
+        "type": "garage",
+        "public_url": "https://www.q-park.de/de-de/staedte/aachen/ebv-carree/",
+        "source_url": null,
+        "address": "Schumacherstraße 12, 52062 Aachen",
+        "capacity": 315,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.092144,
+          50.77732
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp18",
+        "name": "P18-Aquis-Plaza",
+        "type": "garage",
+        "public_url": "https://www.aquis-plaza.de/service/anfahrt-parken/anfahrt/",
+        "source_url": null,
+        "address": "Adalbertstraße 100, Aachen",
+        "capacity": 568,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.0942554,
+          50.774815
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhauscouvenstrasse",
+        "name": "P02-Couvenstrasse",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-couvenstrasse",
+        "address": "Couvenstraße 6, 52062 Aachen",
+        "capacity": 497,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.0899806,
+          50.77744
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhausadalbertstrasse",
+        "name": "P03-Adalbertstrasse",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-adalbertstrasse",
+        "address": "Blondelstraße, 52062 Aachen",
+        "capacity": 186,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.090405,
+          50.775692
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhausrathaus",
+        "name": "P05-Rathaus",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-rathaus",
+        "address": "Mostardstraße 5, 52062 Aachen",
+        "capacity": 400,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.083882,
+          50.777412
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhausgaleriakaufhofcity",
+        "name": "P06-Galeria Kaufhof",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-galeria-kaufhofcity",
+        "address": "Wirichsbongardstr. 47, 52062 Aachen",
+        "capacity": 999,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.09006,
+          50.77298
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhaushauptbahnhof",
+        "name": "P07-Hauptbahnhof",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-hauptbahnhof",
+        "address": "Lagerhausstraße 20, 52064 Aachen",
+        "capacity": 717,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.089069,
+          50.76805
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenparkhausadalbertsteinweg",
+        "name": "P08-Adalbertsteinweg",
+        "type": "garage",
+        "type": "garage",
+        "public_url": "https://www.apag.de/de/parkobjekte/parkhaus-adalbertsteinweg",
+        "address": "Adalbertsteinweg 34, 52070 Aachen",
+        "capacity": 600,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.099605,
+          50.774208
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "aachenp9",
+        "name": "P09-Parkhaus am Dom",
+        "type": "garage",
+        "public_url": null,
+        "source_url": null,
+        "address": "Jesuitenstraße 10, 52062 Aachen",
+        "capacity": 500,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.082303,
+          50.77324
+        ]
+      }
+    }
+  ]
+}

--- a/new/aachen.py
+++ b/new/aachen.py
@@ -1,0 +1,89 @@
+from typing import List
+
+from common.xml_helper import XMLHelper
+from util import LotData, LotInfo, PoolInfo, ScraperBase, guess_lot_type
+
+
+class Aachen(ScraperBase):
+    STATIC_DATA_URL = "https://data.mfdz.de/DATEXII_Parkdaten_statisch_Aachen/body.xml"
+    DYNAMIC_DATA_URL = "https://data.mfdz.de/DATEXII_Parkdaten_dynamisch_Aachen/body.xml"
+    POOL_ID = "aachen"
+
+    POOL = PoolInfo(
+        id=POOL_ID,
+        name="Aachen",
+        public_url="https://mobilithek.info/offers/110000000003300000",
+    )
+
+    AACHEN_TO_APAG_IDS_MAPPING = {
+        'aachenp1': 'aachenparkhauseurogress',
+        'aachenp2': 'aachenparkhauscouvenstrasse',
+        'aachenp3': 'aachenparkhausadalbertstrasse',
+        'aachenp5': 'aachenparkhausrathaus',
+        'aachenp6': 'aachenparkhausgaleriakaufhofcity',
+        'aachenp7': 'aachenparkhaushauptbahnhof',
+        'aachenp8': 'aachenparkhausadalbertsteinweg',
+    }
+
+    def get_lot_data(self) -> List[LotData]:
+        now = self.now()
+        soup = self.request_soup(self.DYNAMIC_DATA_URL, parser="xml")
+        last_updated = self.to_utc_datetime(soup.find("publicationTime").text)
+
+        lots = []
+
+        for facility in soup.select("parkingStatusPublication > parkingRecordStatus"):
+            lot_id = facility.find("parkingRecordReference")["id"]
+            parkingStatusOriginTime = facility.find("parkingStatusOriginTime")
+            last_updated_lot = self.to_utc_datetime(parkingStatusOriginTime.text) if parkingStatusOriginTime else None
+            overrides = facility.find("parkingNumberOfSpacesOverride")
+            lot_total = int(overrides.text) if overrides else None
+            try:
+                lot_occupied = int(facility.find("parkingNumberOfOccupiedSpaces").text)
+            except Exception:
+                lot_occupied = None
+
+            state = facility.find("parkingSiteOpeningStatus")
+            if state and state.text in [LotData.Status.open, LotData.Status.closed]:
+                state = state.text
+            else:
+                state = LotData.Status.nodata
+
+            lots.append(
+                LotData(
+                    id=self.name_to_legacy_id(lot_id),
+                    timestamp=now,
+                    lot_timestamp=last_updated_lot or last_updated,
+                    status=state,
+                    num_occupied=lot_occupied,
+                    capacity=lot_total,
+                )
+            )
+
+        return lots
+
+    def get_lot_infos(self) -> List[LotInfo]:
+        soup = self.request_soup(self.STATIC_DATA_URL, parser="xml")
+
+        lots = []
+        for facility in soup.find_all("parkingRecord"):
+            parkingNumberOfSpaces = facility.find("parkingNumberOfSpaces")
+            capacity = int(parkingNumberOfSpaces.text) if parkingNumberOfSpaces else 0
+            lots.append(
+                LotInfo(
+                    id=self.name_to_legacy_id(facility["id"]),
+                    name=facility.find("parkingName").find("value").text,
+                    type=guess_lot_type(facility.find("parkingLayout").text),
+                    source_url=self.POOL.source_url,
+                    latitude=float(facility.find("pointCoordinates").find("latitude").text),
+                    longitude=float(facility.find("pointCoordinates").find("longitude").text),
+                    capacity=capacity,
+                    has_live_capacity=True,
+                )
+            )
+
+        return lots
+
+    def name_to_legacy_id(self, lot_id):
+        lot_id = super().name_to_legacy_id(lot_id)
+        return self.AACHEN_TO_APAG_IDS_MAPPING.get(lot_id, lot_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ lint.ignore = [
     "C901", # too complex
     "F401", # imported but unused
     "S101", # use of assert detected
+    "Q000",
+    "Q001",
+    "Q003",
 ]
 
 lint.fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]

--- a/util/strings.py
+++ b/util/strings.py
@@ -15,6 +15,7 @@ def guess_lot_type(name: str) -> Optional[str]:
         "parkplätze": LotInfo.Types.lot,
         "parkhaus": LotInfo.Types.garage,
         "parkgarage": LotInfo.Types.garage,
+        "multistorey": LotInfo.Types.garage,
         "tiefgarage": LotInfo.Types.underground,
         "parkdeck": LotInfo.Types.level,
         "parklevel": LotInfo.Types.level,


### PR DESCRIPTION
This PR adds parkings in Aachen, retrieved from the official Mobilithek DATEX2 datasets for static and dynamic parkings. 

The static DATEX2 feed does not provide address and url information
